### PR TITLE
Target ES2020

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "esnext",
+        "target": "ES2020",
         "module": "esnext",
         "lib": ["es2017", "es7", "es6", "dom", "DOM.Iterable"],
         "outDir": "dist",


### PR DESCRIPTION
## What does this change?

Target `ES2020`, following [our recommendations].

[our recommendations]: https://github.com/guardian/recommendations/blob/master/client-side.md#publishing